### PR TITLE
Add optional parameter to disable preserving of instanceState.

### DIFF
--- a/library/src/main/java/de/mrapp/android/tabswitcher/TabSwitcher.java
+++ b/library/src/main/java/de/mrapp/android/tabswitcher/TabSwitcher.java
@@ -223,6 +223,11 @@ public class TabSwitcher extends FrameLayout implements TabSwitcherLayout, Model
     private AbstractTabSwitcherLayout layout;
 
     /**
+     * Whether to preserve the TabSwitcher's state in the onSaveInstanceState() call.
+     */
+    private boolean preserveState = true;
+
+    /**
      * Initializes the view.
      *
      * @param attributeSet
@@ -1967,7 +1972,7 @@ public class TabSwitcher extends FrameLayout implements TabSwitcherLayout, Model
     public final Parcelable onSaveInstanceState() {
         Parcelable superState = super.onSaveInstanceState();
 
-        if (layout != null) {
+        if (layout != null && preserveState) {
             TabSwitcherState savedState = new TabSwitcherState(superState);
             savedState.layoutPolicy = layoutPolicy;
             savedState.modelState = new Bundle();
@@ -1999,7 +2004,7 @@ public class TabSwitcher extends FrameLayout implements TabSwitcherLayout, Model
 
     @Override
     public final void onRestoreInstanceState(final Parcelable state) {
-        if (state instanceof TabSwitcherState) {
+        if (state instanceof TabSwitcherState && preserveState) {
             TabSwitcherState savedState = (TabSwitcherState) state;
             this.layoutPolicy = savedState.layoutPolicy;
             model.restoreInstanceState(savedState.modelState);
@@ -2009,4 +2014,11 @@ public class TabSwitcher extends FrameLayout implements TabSwitcherLayout, Model
         }
     }
 
+    /**
+     * Optionally enable or disable preserving of the full state of the TabSwitcher.
+     * @param enabled Whether to enable preserving the state.
+     */
+    public void setPreserveState(boolean enabled) {
+        preserveState = enabled;
+    }
 }


### PR DESCRIPTION
This adds an optional parameter to enable or disable preserving the instance state of the TabSwitcher. If the state is disabled, it successfully fixes #22, #23, and #24, at the cost of losing just a bit of state information, but we believe this is a fair tradeoff while these crashes can be investigated further.

@michael-rapp Would you consider merging this pull request and releasing an updated version? It would resolve a good number of the crashes that we are seeing.
